### PR TITLE
Fix reading msat_wr_kp_hy.py when reading from a remote server.

### DIFF
--- a/api/msat_wr_kp.py
+++ b/api/msat_wr_kp.py
@@ -140,13 +140,12 @@ parser.add_option(
   help = "kickstart label"
 )
 (options, args) = config.get_conf(parser)
-
 if options.satellite_url is None:
   parser.error('Error: specify URL, -u or --satellite-url')
 if options.satellite_login is None:
-  parser.error('Error: specify login, -l or --login')
+  parser.error('Error: specify login, -a or --satellite-login')
 if options.satellite_password is None:
-  parser.error('Error: specify password, -p or --password')
+  parser.error('Error: specify password, -p or --satellite-password')
 if options.kickstart_label is None:
   parser.error('specify kickstart label, -l or --kickstart-label. Use list_kickstart_profiles.py to find all kickstart labels.')
 

--- a/api/msat_wr_kp_hy.py
+++ b/api/msat_wr_kp_hy.py
@@ -171,7 +171,7 @@ script_path = os.path.join(save_path, script)
 f = open(script_path, 'w')
 os.chmod(script_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
-subprocess.Popen([satellite_api_dir + '/msat_wr_kp.py', '--kickstart-label', options.kickstart_label], stdout=f, stderr=subprocess.STDOUT)
+subprocess.Popen([satellite_api_dir + '/msat_wr_kp.py', '--kickstart-label', options.kickstart_label, '--satellite-url', options.satellite_url , '--satellite-login', options.satellite_login , '--satellite-password', options.satellite_password], stdout=f, stderr=subprocess.STDOUT)
 f.close()
 
 try:
@@ -221,7 +221,7 @@ for a in akeys:
   f = open(script_path, 'w')
   os.chmod(script_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
-  subprocess.Popen([satellite_api_dir + '/msat_wr_ak.py', '--activationkey-label', a['key']], stdout=f, stderr=subprocess.STDOUT)
+  subprocess.Popen([satellite_api_dir + '/msat_wr_ak.py', '--activationkey-label', a['key'], '--satellite-url', options.satellite_url , '--satellite-login', options.satellite_login , '--satellite-password', options.satellite_password], stdout=f, stderr=subprocess.STDOUT)
   f.close()
   try:
     config_channels = client.activationkey.listConfigChannels(


### PR DESCRIPTION
And here's the pull request for sending the credentials from msat_wr_kp_hy.py to the underlying scripts. This is both useful when the Satellite server is remote or you need to use different credentials than set in your msat configuration.

Gerben
