### PR TITLE
Treat 'reboot' parameter as a boolean

### DIFF
--- a/api/msat_mk_kp.py
+++ b/api/msat_mk_kp.py
@@ -470,10 +470,10 @@ parser.add_option(
 parser.add_option(
   "--kickstart-reboot",
   action   = "callback",
-  callback = config.parse_string,
+  callback = config.parse_boolean,
   dest     = "kickstart_reboot",
   type     = "string",
-  default  = "true",
+  default  = True,
   help     = "reboot kickstart advanced option"
 )
 parser.add_option(


### PR DESCRIPTION
Without this patch the 'reboot' parameter is always set to 'True' and the setting from the msat script is disregarded. For clusternodes we need to be able to set this to false, so the clusternodes can be brought up simultaneously to form a cluster.
